### PR TITLE
047 pressure dump error

### DIFF
--- a/dassh/assembly.py
+++ b/dassh/assembly.py
@@ -755,13 +755,14 @@ class Assembly(LoggedClass):
         # Pressure drop update
         if 'pressure_drop' in dfiles.keys():
             write_step['pressure_drop'][0, 3] = self.pressure_drop
-            _dp = {'friction': 0.0, 'spacer_grid': 0.0, 'gravity': 0.0}
-            for reg in self.region:
-                for k in reg._pressure_drop.keys():
-                    _dp[k] += reg._pressure_drop[k]
-            write_step['pressure_drop'][0, 4] = _dp['friction']
-            write_step['pressure_drop'][0, 5] = _dp['spacer_grid']
-            write_step['pressure_drop'][0, 6] = _dp['gravity']
+            if write_step['pressure_drop'].shape[1] > 4:
+                _dp = {'friction': 0.0, 'spacer_grid': 0.0, 'gravity': 0.0}
+                for reg in self.region:
+                    for k in reg._pressure_drop.keys():
+                        _dp[k] += reg._pressure_drop[k]
+                write_step['pressure_drop'][0, 4] = _dp['friction']
+                write_step['pressure_drop'][0, 5] = _dp['spacer_grid']
+                write_step['pressure_drop'][0, 6] = _dp['gravity']
             np.savetxt(dfiles['pressure_drop'],
                        write_step['pressure_drop'],
                        delimiter=',')

--- a/dassh/reactor.py
+++ b/dassh/reactor.py
@@ -1012,7 +1012,10 @@ class Reactor(LoggedClass):
         self._options['dump']['cols'] = {}
         self._options['dump']['cols']['average'] = 10
         self._options['dump']['cols']['maximum'] = 7
-        self._options['dump']['cols']['pressure_drop'] = 7
+        if self._options['mixed_convection']:
+            self._options['dump']['cols']['pressure_drop'] = 4
+        else:
+            self._options['dump']['cols']['pressure_drop'] = 7
         self._options['dump']['cols']['coolant_int'] = 3 + max(
             [a.rodded.subchannel.n_sc['coolant']['total']
              if a.has_rodded else 1 for a in self.assemblies])


### PR DESCRIPTION
When dealing with the mixed convection solver, an error arises if the user requests the dumping of the pressure drop results. This error emerges from the unavailability of the single contributions to the total pressure drop. 

To solve this, I defined a different structure to host the results of the pressure drop depending on the convection regime. In the case of forced convection, nothing changes. For mixed convection, only the total pressure drop is dumped, eliminating the need for extra columns.