### PR TITLE
051 singular matrix error

### DIFF
--- a/dassh/region_mixed.py
+++ b/dassh/region_mixed.py
@@ -12,6 +12,7 @@ from dassh.region_rodded import RoddedRegion, calculate_ht_constants, \
 from dassh._commons import GRAVITY_CONST, MIX_CON_VERBOSE_OUTPUT, \
     MC_MAX_ITER, MIXED_CONV_PROP_TO_UPDATE
 import sys
+from typing import Union
 
 
 def make(inp, name, mat, fr, se2geo=False, update_tol=0.0, 
@@ -367,8 +368,9 @@ class MixedRegion(RoddedRegion):
         # Build energy terms of the known vector
         energy_b = qq * dz / self.params['area'][self.subchannel.type[:nn]] \
             + EEX + self._hstar * ((self._sc_vel + self._delta_v)
-                                   *self._delta_rho + 
-                                   self.sc_properties['density']*self._delta_v)
+                                   * self._delta_rho + 
+                                   self.sc_properties['density'] * 
+                                   self._delta_v)
         # Wall convection term
         self._qw = self._wall_convection() * dz 
         energy_b[self.ht['conv']['ind']] += self._qw  / self.params['area'][
@@ -578,7 +580,7 @@ class MixedRegion(RoddedRegion):
 
     def _calc_star_quantity(self, delta_v: np.ndarray, delta_rho: np.ndarray, 
                             nn: int, variable: str, 
-                            RR: np.ndarray = None) -> np.ndarray:
+                            RR: Union[np.ndarray, None] = None) -> np.ndarray:
         """
         Update hstar or vstar
         
@@ -593,15 +595,20 @@ class MixedRegion(RoddedRegion):
         variable : str
             Indicate whether to calculate hstar or vstar; 
             options are 'h' or 'v'
-        RR : np.ndarray
-            Enthalpy variation coefficient (J*m^3/kg^2);
-            Optional, only used for hstar calculation
+        RR : Union[np.ndarray, None], optional
+            Derivative of enthalpy with respect to density (J*m^3/kg^2);
+            Only used for hstar calculation
 
         Returns
         -------
         np.ndarray
             Calculated star quantity for each subchannel
 
+        Raises
+        ------
+        ValueError
+            If `variable` is not 'h' or 'v'
+            
         Notes
         -----
         Two options are available:
@@ -621,7 +628,7 @@ class MixedRegion(RoddedRegion):
         if not self._accurate_star_quantities:
             return star_mid
         # OPTION 2: Calculate hstar or vstar as per Cheng 
-        numerator_v = np.zeros(nn)
+        numerator = np.zeros(nn)
         sum_den = np.zeros(nn)
         # Calculate delta_m for each subchannel
         vrho_1 = self.sc_properties['density'] * self._sc_vel 
@@ -632,7 +639,7 @@ class MixedRegion(RoddedRegion):
         # Iterate over subchannels and adjacent subchannels
         for i in range(nn):
             denominator = 0.0
-            num_v = 0.0
+            num = 0.0
             for k in range(3):
                 j = self.ht['cond']['adj'][i][k]
                 if i in self.ht['conv']['ind'][self.ht['conv']['type'] == 2] \
@@ -641,14 +648,14 @@ class MixedRegion(RoddedRegion):
                 # Calculate delta_m difference between adjacent subchannel
                 xij = delta_m[i] - delta_m[j]
                 # Calculate numerators and denominators
-                num_v += self._calc_star_quantity_numerator(
+                num += self._calc_star_quantity_numerator(
                     star_mid[i], star_mid[j], xij)
                 denominator += np.abs(xij)
-            numerator_v[i] = num_v
+            numerator[i] = num
             sum_den[i] = denominator      
         # Calculate hstar and vstar
         sum_den = 2 * sum_den + sys.float_info.epsilon 
-        return numerator_v / sum_den
+        return numerator / sum_den
         
         
     def _calc_star_quantity_numerator(self, var_mid_i: float, var_mid_j: float,

--- a/dassh/region_mixed.py
+++ b/dassh/region_mixed.py
@@ -305,6 +305,8 @@ class MixedRegion(RoddedRegion):
         # Update energy balance if requested
         # Calculated as:
         # Q_in [from z to z+dz] - (m*delta_h)_(z+dz) + (m*delta_h)_(z) = err
+        self._hstar = self._calc_star_quantity(delta_v0, delta_rho0, nn, 
+                                               'h', RR)
         if ebal:
             mcpdT_i = self.sc_mfr * self._enthalpy - mdh_old
             # Error introduced in the energy balance by h_star approximation
@@ -364,7 +366,9 @@ class MixedRegion(RoddedRegion):
              self.params['de'][self.subchannel.type[:nn]])
         # Build energy terms of the known vector
         energy_b = qq * dz / self.params['area'][self.subchannel.type[:nn]] \
-            + EEX
+            + EEX + self._hstar * ((self._sc_vel + self._delta_v)
+                                   *self._delta_rho + 
+                                   self.sc_properties['density']*self._delta_v)
         # Wall convection term
         self._qw = self._wall_convection() * dz 
         energy_b[self.ht['conv']['ind']] += self._qw  / self.params['area'][
@@ -548,7 +552,7 @@ class MixedRegion(RoddedRegion):
         AA : np.ndarray
             Coefficient matrix for the system to solve
         """
-        self._calc_h_v_star(delta_v, delta_rho, RR, nn)
+        self._vstar = self._calc_star_quantity(delta_v, delta_rho, nn, 'v')
         # Calculate coefficients for the matrix
         EE, FF = self._calc_momentum_coefficients(nn, dz, delta_v)
         SS, TT = self._calc_energy_coefficients(delta_v, delta_rho, RR)
@@ -572,10 +576,11 @@ class MixedRegion(RoddedRegion):
         return AA
 
 
-    def _calc_h_v_star(self, delta_v: np.ndarray, delta_rho: np.ndarray, 
-                       RR: np.ndarray, nn: int) -> None:
+    def _calc_star_quantity(self, delta_v: np.ndarray, delta_rho: np.ndarray, 
+                            nn: int, variable: str, 
+                            RR: np.ndarray = None) -> np.ndarray:
         """
-        Update hstar and vstar
+        Update hstar or vstar
         
         Parameters
         ----------
@@ -583,11 +588,20 @@ class MixedRegion(RoddedRegion):
             Variation of the SC velocities (m/s)
         delta_rho : np.ndarray
             Variation of the SC densities (kg/m^3)
-        RR : np.ndarray
-            Enthalpy variation coefficient (J*m^3/kg^2)
         nn : int
             Number of coolant subchannels
-            
+        variable : str
+            Indicate whether to calculate hstar or vstar; 
+            options are 'h' or 'v'
+        RR : np.ndarray
+            Enthalpy variation coefficient (J*m^3/kg^2);
+            Optional, only used for hstar calculation
+
+        Returns
+        -------
+        np.ndarray
+            Calculated star quantity for each subchannel
+
         Notes
         -----
         Two options are available:
@@ -597,15 +611,16 @@ class MixedRegion(RoddedRegion):
            Correlations for wire-wrapped subchannel analysis under forced and
            mixed convection conditions (Ph.D. thesis). MIT."
         """
-        h_mid = self._enthalpy + RR * delta_rho / 2
-        v_mid = self._sc_vel + delta_v / 2
-        # OPTION 1: Approximate hstar and vstar as midpoints
+        if variable != 'h' and variable != 'v':
+            raise ValueError("Invalid variable for star quantity calculation.")
+        if variable == 'h':
+            star_mid = self._enthalpy + RR * delta_rho / 2
+        else:
+            star_mid = self._sc_vel + delta_v / 2
+        # OPTION 1: Approximate hstar or vstar as midpoints
         if not self._accurate_star_quantities:
-            self._hstar = h_mid
-            self._vstar = v_mid
-            return
-        # OPTION 2: Calculate hstar and vstar as per Cheng 
-        numerator_h = np.zeros(nn)
+            return star_mid
+        # OPTION 2: Calculate hstar or vstar as per Cheng 
         numerator_v = np.zeros(nn)
         sum_den = np.zeros(nn)
         # Calculate delta_m for each subchannel
@@ -617,7 +632,6 @@ class MixedRegion(RoddedRegion):
         # Iterate over subchannels and adjacent subchannels
         for i in range(nn):
             denominator = 0.0
-            num_h = 0.0
             num_v = 0.0
             for k in range(3):
                 j = self.ht['cond']['adj'][i][k]
@@ -627,18 +641,14 @@ class MixedRegion(RoddedRegion):
                 # Calculate delta_m difference between adjacent subchannel
                 xij = delta_m[i] - delta_m[j]
                 # Calculate numerators and denominators
-                num_h += self._calc_star_quantity_numerator(
-                    h_mid[i], h_mid[j], xij)
                 num_v += self._calc_star_quantity_numerator(
-                    v_mid[i], v_mid[j], xij)
+                    star_mid[i], star_mid[j], xij)
                 denominator += np.abs(xij)
-            numerator_h[i] = num_h
             numerator_v[i] = num_v
             sum_den[i] = denominator      
         # Calculate hstar and vstar
         sum_den = 2 * sum_den + sys.float_info.epsilon 
-        self._hstar = numerator_h / sum_den
-        self._vstar = numerator_v / sum_den
+        return numerator_v / sum_den
         
         
     def _calc_star_quantity_numerator(self, var_mid_i: float, var_mid_j: float,
@@ -725,10 +735,9 @@ class MixedRegion(RoddedRegion):
             - SS coefficients 
             - TT coefficients
         """
-        SS = (self._sc_vel + delta_v) * \
-            (self._enthalpy - self._hstar + 
+        SS = (self._sc_vel + delta_v) * (self._enthalpy  + 
              RR * (self.sc_properties['density'] + delta_rho))
-        TT = self.sc_properties['density'] * (self._enthalpy - self._hstar)
+        TT = self.sc_properties['density'] * self._enthalpy 
         return SS, TT
 
 

--- a/tests/test_region_mixed.py
+++ b/tests/test_region_mixed.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 import dassh
 from pytest import rr_data
-from tests.test_region_rodded import mock_AssemblyPower
+from tests.test_region_rodded import mock_AssemblyPower, mock_ZeroAssemblyPower
 from dassh._commons import rho2h_COEFF_FILE
 
 
@@ -216,6 +216,35 @@ class TestBalances():
                                       mfr_1, mfr_2)
 
 
+    def test_axial_step_zero_power(self, 
+                                simple_ctrl_rr_mixconv: dassh.MixedRegion):
+        """
+        Test that the axial step energy, momentum and mass balances are
+        satisfied
+        
+        Parameters
+        ----------
+        simple_ctrl_rr_mixconv : dassh.MixedRegion
+            The mixed region object to test
+        """
+        q = mock_ZeroAssemblyPower(simple_ctrl_rr_mixconv)
+        _assign_parameters(simple_ctrl_rr_mixconv)
+        # Store mass flow rates, enthalpies and velocities at state 1
+        mfr_1 = simple_ctrl_rr_mixconv.sc_mfr.copy()
+        h_1 = simple_ctrl_rr_mixconv._enthalpy.copy()
+        # Solve for state 2
+        simple_ctrl_rr_mixconv._solve_system(rr_data.enthalpy['dz'], 
+                                             rr_data.enthalpy['dz'], 
+                                             q['pins'],
+                                             q['cool'],
+                                             ebal=False)
+        # Store mass flow rates, enthalpies and velocities at state 2 
+        mfr_2 = simple_ctrl_rr_mixconv.sc_mfr.copy()
+        h_2 = simple_ctrl_rr_mixconv._enthalpy.copy()
+        # Conservation of energy
+        self._assert_energy_balance(q, mfr_1, h_1, mfr_2, h_2, 
+                                    simple_ctrl_rr_mixconv)
+        
 class TestMethodsMixedRegion():
     """
     Class to test methods in the MixedRegion class

--- a/tests/test_region_mixed.py
+++ b/tests/test_region_mixed.py
@@ -217,10 +217,10 @@ class TestBalances():
 
 
     def test_axial_step_zero_power(self, 
-                                simple_ctrl_rr_mixconv: dassh.MixedRegion):
+                                   simple_ctrl_rr_mixconv: dassh.MixedRegion):
         """
-        Test that the axial step energy, momentum and mass balances are
-        satisfied
+        Test that the simulation runs with zero power and that the Delta(mh) 
+        term is equal to zero
         
         Parameters
         ----------
@@ -229,7 +229,7 @@ class TestBalances():
         """
         q = mock_ZeroAssemblyPower(simple_ctrl_rr_mixconv)
         _assign_parameters(simple_ctrl_rr_mixconv)
-        # Store mass flow rates, enthalpies and velocities at state 1
+        # Store mass flow rates and enthalpies at state 1
         mfr_1 = simple_ctrl_rr_mixconv.sc_mfr.copy()
         h_1 = simple_ctrl_rr_mixconv._enthalpy.copy()
         # Solve for state 2
@@ -238,12 +238,15 @@ class TestBalances():
                                              q['pins'],
                                              q['cool'],
                                              ebal=False)
-        # Store mass flow rates, enthalpies and velocities at state 2 
+        # Store mass flow rates and enthalpies at state 2 
         mfr_2 = simple_ctrl_rr_mixconv.sc_mfr.copy()
         h_2 = simple_ctrl_rr_mixconv._enthalpy.copy()
         # Conservation of energy
         self._assert_energy_balance(q, mfr_1, h_1, mfr_2, h_2, 
                                     simple_ctrl_rr_mixconv)
+        assert mfr_2 * h_2 - mfr_1 * h_1 == pytest.approx(
+            0, abs=rr_data.mixed['tol']
+            )
         
 class TestMethodsMixedRegion():
     """

--- a/tests/test_region_mixed.py
+++ b/tests/test_region_mixed.py
@@ -242,9 +242,14 @@ class TestMethodsMixedRegion():
         expected_vstar : np.ndarray
             The expected vstar values
         """                              
-        rm._calc_h_v_star(dv, drho, RR, rm.subchannel.n_sc['coolant']['total'])
+        rm._hstar = rm._calc_star_quantity(
+            dv, drho, rm.subchannel.n_sc['coolant']['total'], 'h', RR
+            )
         assert rm._hstar == pytest.approx(expected_hstar, 
-                                         abs=rr_data.mixed['tol'])
+                                          abs=rr_data.mixed['tol'])
+        rm._vstar = rm._calc_star_quantity(
+            dv, drho, rm.subchannel.n_sc['coolant']['total'], 'v', RR
+            )
         assert rm._vstar == pytest.approx(expected_vstar, 
                                          abs=rr_data.mixed['tol'])
     

--- a/tests/test_region_rodded.py
+++ b/tests/test_region_rodded.py
@@ -38,7 +38,17 @@ def mock_AssemblyPower(rregion):
             + rr_data.mock_AP['duct'][1],
             'cool': np.random.random(n_cool_sc) + rr_data.mock_AP['cool']}
     
-
+def mock_ZeroAssemblyPower(rregion):
+    """Fake a dictionary of zero linear power like that produced by the
+    DASSH AssemblyPower object"""
+    n_pin = rregion.n_pin
+    n_duct_sc = rregion.subchannel.n_sc['duct']['total']
+    n_cool_sc = rregion.subchannel.n_sc['coolant']['total']
+    return {'pins': np.zeros(n_pin),
+            'duct': np.zeros(n_duct_sc),
+            'cool': np.zeros(n_cool_sc)} 
+    
+    
 class TestMiscellaneous():
     """
     Class to test the flowsplit and the correlation assignment in the RoddedRegion


### PR DESCRIPTION
An issue related to a singular matrix error occurring in the mixed convection solver was reported by @Nino-ndrk.

The detailed explanation of the bug and the approach used to resolve it can be found in https://github.com/newcleo-dev-team/dassh_nc/issues/51#issuecomment-5003635919.